### PR TITLE
remove css imports from modules for nextjs

### DIFF
--- a/src/SidebarNav.js
+++ b/src/SidebarNav.js
@@ -4,7 +4,7 @@ import { Badge, Nav, NavItem, NavLink as RsNavLink } from 'reactstrap';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import PerfectScrollbar from 'react-perfect-scrollbar';
-import 'react-perfect-scrollbar/dist/css/styles.css';
+// import 'react-perfect-scrollbar/dist/css/styles.css';
 
 const propTypes = {
   children: PropTypes.node,

--- a/src/SidebarNav2.js
+++ b/src/SidebarNav2.js
@@ -3,8 +3,8 @@ import { Badge, Nav, NavItem, NavLink as RsNavLink } from 'reactstrap';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import PerfectScrollbar from 'react-perfect-scrollbar';
-import 'react-perfect-scrollbar/dist/css/styles.css';
-import '../css/scrollbar.css';
+// import 'react-perfect-scrollbar/dist/css/styles.css';
+// import '../css/scrollbar.css';
 
 import LayoutHelper from './Shared/layout/layout'
 


### PR DESCRIPTION
first step in making coreui/react work in nextjs, under forked local branch.